### PR TITLE
Apply permissions in the JobScript and JobSubmission

### DIFF
--- a/jobbergateapi2/apps/job_submissions/routers.py
+++ b/jobbergateapi2/apps/job_submissions/routers.py
@@ -6,10 +6,11 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, status
 
-from jobbergateapi2.apps.auth.authentication import get_current_user
+from jobbergateapi2.apps.auth.authentication import Permission, get_current_user
 from jobbergateapi2.apps.job_scripts.models import job_scripts_table
 from jobbergateapi2.apps.job_submissions.models import job_submissions_table
 from jobbergateapi2.apps.job_submissions.schemas import JobSubmission, JobSubmissionRequest
+from jobbergateapi2.apps.permissions.routers import resource_acl_as_list
 from jobbergateapi2.apps.users.schemas import User
 from jobbergateapi2.compat import INTEGRITY_CHECK_EXCEPTIONS
 from jobbergateapi2.storage import database
@@ -17,10 +18,18 @@ from jobbergateapi2.storage import database
 router = APIRouter()
 
 
+async def job_submissions_acl_as_list():
+    """
+    Return the permissions as list for the JobSubmission resoruce.
+    """
+    return await resource_acl_as_list("job_submission")
+
+
 @router.post("/job-submissions/", status_code=201, description="Endpoint for job_submission creation")
 async def job_submission_create(
     job_submission: JobSubmissionRequest,
     current_user: User = Depends(get_current_user),
+    acls: list = Permission("create", job_submissions_acl_as_list),
 ):
     """
     Create a new job submission.
@@ -55,7 +64,9 @@ async def job_submission_create(
     response_model=JobSubmission,
 )
 async def job_submission_get(
-    job_submission_id: int = Query(...), current_user: User = Depends(get_current_user)
+    job_submission_id: int = Query(...),
+    current_user: User = Depends(get_current_user),
+    acls: list = Permission("view", job_submissions_acl_as_list),
 ):
     """
     Return the job_submission given it's id.
@@ -76,7 +87,9 @@ async def job_submission_get(
     "/job-submissions/", description="Endpoint to list job_submissions", response_model=List[JobSubmission]
 )
 async def job_submission_list(
-    all: Optional[bool] = Query(None), current_user: User = Depends(get_current_user)
+    all: Optional[bool] = Query(None),
+    current_user: User = Depends(get_current_user),
+    acls: list = Permission("view", job_submissions_acl_as_list),
 ):
     """
     List job_submissions for the authenticated user.
@@ -101,6 +114,7 @@ async def job_submission_list(
 async def job_submission_delete(
     current_user: User = Depends(get_current_user),
     job_submission_id: int = Query(..., description="id of the job submission to delete"),
+    acls: list = Permission("delete", job_submissions_acl_as_list),
 ):
     """
     Delete job_submission given its id.
@@ -130,6 +144,7 @@ async def job_script_update(
     job_submission_name: Optional[str] = Form(None),
     job_submission_description: Optional[str] = Form(None),
     current_user: User = Depends(get_current_user),
+    acls: list = Permission("update", job_submissions_acl_as_list),
 ):
     """
     Update a job_submission given its id.

--- a/jobbergateapi2/apps/permissions/models.py
+++ b/jobbergateapi2/apps/permissions/models.py
@@ -12,3 +12,19 @@ application_permissions_table = Table(
     Column("id", Integer, primary_key=True),
     Column("acl", String, nullable=False, unique=True),
 )
+
+
+job_script_permissions_table = Table(
+    "job_script_permissions",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("acl", String, nullable=False, unique=True),
+)
+
+
+job_submission_permissions_table = Table(
+    "job_submission_permissions",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("acl", String, nullable=False, unique=True),
+)

--- a/jobbergateapi2/apps/permissions/routers.py
+++ b/jobbergateapi2/apps/permissions/routers.py
@@ -8,8 +8,18 @@ from fastapi_permissions import Allow, Authenticated, Deny
 from pydantic import ValidationError
 
 from jobbergateapi2.apps.auth.authentication import get_current_user
-from jobbergateapi2.apps.permissions.models import application_permissions_table
-from jobbergateapi2.apps.permissions.schemas import _ACL_RX, ApplicationPermission, BasePermission
+from jobbergateapi2.apps.permissions.models import (
+    application_permissions_table,
+    job_script_permissions_table,
+    job_submission_permissions_table,
+)
+from jobbergateapi2.apps.permissions.schemas import (
+    _ACL_RX,
+    ApplicationPermission,
+    BasePermission,
+    JobScriptPermission,
+    JobSubmissionPermission,
+)
 from jobbergateapi2.apps.users.schemas import User
 from jobbergateapi2.compat import INTEGRITY_CHECK_EXCEPTIONS
 from jobbergateapi2.storage import database
@@ -18,8 +28,16 @@ router = APIRouter()
 
 
 _QUERY_RX = r"^(application|job_script|job_submission)$"
-permission_classes = {"application": ApplicationPermission}
-permission_tables = {"application": application_permissions_table}
+permission_classes = {
+    "application": ApplicationPermission,
+    "job_script": JobScriptPermission,
+    "job_submission": JobSubmissionPermission,
+}
+permission_tables = {
+    "application": application_permissions_table,
+    "job_script": job_script_permissions_table,
+    "job_submission": job_submission_permissions_table,
+}
 
 
 async def resource_acl_as_list(permission_query):

--- a/jobbergateapi2/apps/permissions/schemas.py
+++ b/jobbergateapi2/apps/permissions/schemas.py
@@ -27,3 +27,15 @@ class ApplicationPermission(BasePermission):
     """
     Permission model for the Application resource.
     """
+
+
+class JobScriptPermission(BasePermission):
+    """
+    Permission model for the JobScript resource.
+    """
+
+
+class JobSubmissionPermission(BasePermission):
+    """
+    Permission model for the JobSubmission resource.
+    """

--- a/jobbergateapi2/tests/apps/permissions/test_routers.py
+++ b/jobbergateapi2/tests/apps/permissions/test_routers.py
@@ -4,10 +4,19 @@ Tests for the /permissions/ endpoint.
 import nest_asyncio
 import pytest
 from fastapi import status
+from fastapi_permissions import Allow, Authenticated, Deny
 
-from jobbergateapi2.apps.permissions.models import application_permissions_table
-from jobbergateapi2.apps.permissions.routers import _QUERY_RX
-from jobbergateapi2.apps.permissions.schemas import ApplicationPermission
+from jobbergateapi2.apps.permissions.models import (
+    application_permissions_table,
+    job_script_permissions_table,
+    job_submission_permissions_table,
+)
+from jobbergateapi2.apps.permissions.routers import _QUERY_RX, resource_acl_as_list
+from jobbergateapi2.apps.permissions.schemas import (
+    ApplicationPermission,
+    JobScriptPermission,
+    JobSubmissionPermission,
+)
 from jobbergateapi2.apps.users.models import users_table
 from jobbergateapi2.apps.users.schemas import UserCreate
 from jobbergateapi2.storage import database
@@ -28,7 +37,11 @@ def test_query_regex():
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -63,7 +76,11 @@ async def test_create_permissions(user_data, client, permission_class, permissio
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -100,7 +117,11 @@ async def test_create_permissions_duplicated(
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -163,7 +184,11 @@ async def test_create_permissions_with_bad_query_string(user_data, client):
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -191,7 +216,11 @@ async def test_create_permissions_invalid_acl(
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -225,7 +254,11 @@ async def test_list_permissions(user_data, client, permission_class, permission_
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -282,7 +315,11 @@ async def test_list_permissions_without_query_string(user_data, client):
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -316,7 +353,11 @@ async def test_delete_permissions(user_data, client, permission_class, permissio
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -353,7 +394,11 @@ async def test_delete_permissions_not_superuser(
 
 @pytest.mark.parametrize(
     "permission_class,permission_table,permission_query",
-    [(ApplicationPermission, application_permissions_table, "application")],
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
 )
 @pytest.mark.asyncio
 @database.transaction(force_rollback=True)
@@ -418,3 +463,50 @@ async def test_delete_permissions_without_query_string(user_data, client):
 
     response = client.delete("/permissions/1")
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "permission_class,permission_table,permission_query",
+    [
+        (ApplicationPermission, application_permissions_table, "application"),
+        (JobScriptPermission, job_script_permissions_table, "job_script"),
+        (JobSubmissionPermission, job_submission_permissions_table, "job_submission"),
+    ],
+)
+@pytest.mark.asyncio
+@database.transaction(force_rollback=True)
+async def test_resource_acl_as_list(permission_class, permission_table, permission_query):
+    """
+    Test that the resource_acl_as_list function returns the correct result.
+
+    We show this by asserting the return of the function with the expected output.
+    """
+    permissions = [
+        permission_class(id=1, acl="Allow|role:admin|create"),
+        permission_class(id=2, acl="Deny|Authenticated|delete"),
+    ]
+    await insert_objects(permissions, permission_table)
+
+    acl = await resource_acl_as_list(permission_query)
+
+    assert acl == [
+        (Allow, "role:admin", "create"),
+        (Deny, Authenticated, "delete"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "permission_query",
+    [("application"), ("job_script"), ("job_submission")],
+)
+@pytest.mark.asyncio
+@database.transaction(force_rollback=True)
+async def test_resource_acl_as_list_empty(permission_query):
+    """
+    Test that the resource_acl_as_list returns an empty list when there is nothing in the database.
+
+    We show this by asserting the return of the function with an empty list.
+    """
+    acl = await resource_acl_as_list(permission_query)
+
+    assert acl == []

--- a/jobbergateapi2/tests/apps/permissions/test_schemas.py
+++ b/jobbergateapi2/tests/apps/permissions/test_schemas.py
@@ -4,7 +4,12 @@ Test the schema of the resource Permission.
 import pytest
 from pydantic import ValidationError
 
-from jobbergateapi2.apps.permissions.schemas import _ACL_RX, ApplicationPermission
+from jobbergateapi2.apps.permissions.schemas import (
+    _ACL_RX,
+    ApplicationPermission,
+    JobScriptPermission,
+    JobSubmissionPermission,
+)
 
 
 def test_acl_regex():
@@ -14,7 +19,9 @@ def test_acl_regex():
     assert _ACL_RX == r"^(Allow|Deny)\|(role:\w+|Authenticated)\|\w+$"
 
 
-@pytest.mark.parametrize("permission_class", [(ApplicationPermission)])
+@pytest.mark.parametrize(
+    "permission_class", [(ApplicationPermission), (JobScriptPermission), (JobSubmissionPermission)]
+)
 @pytest.mark.parametrize(
     "acl",
     [
@@ -35,7 +42,9 @@ def test_create_permission_bad_acl(acl, permission_class):
         permission_class(acl=acl)
 
 
-@pytest.mark.parametrize("permission_class", [(ApplicationPermission)])
+@pytest.mark.parametrize(
+    "permission_class", [(ApplicationPermission), (JobScriptPermission), (JobSubmissionPermission)]
+)
 @pytest.mark.parametrize(
     "acl",
     [


### PR DESCRIPTION
Apply the permissions in all endpoints for all the resources.