### PR TITLE
Add endpoint to list all permissions at once

### DIFF
--- a/jobbergateapi2/apps/permissions/schemas.py
+++ b/jobbergateapi2/apps/permissions/schemas.py
@@ -6,6 +6,7 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 _ACL_RX = r"^(Allow|Deny)\|(role:\w+|Authenticated)\|\w+$"
+_RESOURCE_RX = r"^(application|job_script|job_submission)$"
 
 
 class BasePermission(BaseModel):
@@ -39,3 +40,11 @@ class JobSubmissionPermission(BasePermission):
     """
     Permission model for the JobSubmission resource.
     """
+
+
+class AllPermissions(BasePermission):
+    """
+    Schema to return all permissions.
+    """
+
+    resource_name: str = Field(..., regex=_RESOURCE_RX)

--- a/jobbergateapi2/apps/permissions/schemas.py
+++ b/jobbergateapi2/apps/permissions/schemas.py
@@ -44,7 +44,7 @@ class JobSubmissionPermission(BasePermission):
 
 class AllPermissions(BasePermission):
     """
-    Schema to return all permissions.
+    Store the permission resource.
     """
 
     resource_name: str = Field(..., regex=_RESOURCE_RX)

--- a/jobbergateapi2/tests/apps/permissions/test_routers.py
+++ b/jobbergateapi2/tests/apps/permissions/test_routers.py
@@ -516,10 +516,11 @@ async def test_resource_acl_as_list_empty(permission_query):
 @database.transaction(force_rollback=True)
 async def test_list_permissions_all(user_data, client):
     """
-    Test the GET in the /permissions/all returns the list of all existing Permissions.
+    Test that GET /permissions/all returns a list of all existing Permissions.
 
-    We show this by creating 3 permissions, making the GET request to the /permissions/all endpoint,
-    then asserting the response status code is 200, and the content of the response is as expected.
+    We show this by creating 3 permissions followed by a GET request to the /permissions/all endpoint and
+    finally asserting the response status code is 200 and the response contains the correct number of
+    Permissions.
     """
     user = [UserCreate(**user_data)]
     await insert_objects(user, users_table)
@@ -554,8 +555,9 @@ async def test_list_permissions_all_empty(user_data, client):
     """
     Test the GET in the /permissions/all returns the list of existing Permissions even when there is none.
 
-    We by making the GET request to the /permissions/all endpoint without any  permission created, then
-    asserting the response status code is 200, and the content of the response is as expected.
+    We prove that GET /permissions/all returns correctly even when no permissions exist by making a GET
+    request to the /permissions/all endpoint without any existing permissions entries in the database.
+    Finally assert the response status code is 200 and the number of Permission returned is 0.
     """
     user = [UserCreate(**user_data)]
     await insert_objects(user, users_table)


### PR DESCRIPTION
For the frontend needs the /permissions/all will now list all the permissions with a extra field `resouce_name` with the name of the resource (`application`, `job_script` or `job_submission`).